### PR TITLE
Exit with non-zero status on failure

### DIFF
--- a/bin/slug-compiler
+++ b/bin/slug-compiler
@@ -13,10 +13,12 @@ begin
   # TODO: unify this with existing logging
 rescue SlugCompiler::CompileFail => e
   puts(" !     Heroku push rejected, #{e.message}\n")
+  abort
 rescue SlugCompiler::CompileError => e
   puts(" !     Heroku push rejected, #{e.message}\n")
   SlugCompiler.log("measure=slugc.fail elapsed=#{Time.now - start} " \
                    "message='#{e.message}'")
+  abort
 rescue => e
   puts
   puts(" !     Heroku push rejected due to an unrecognized error.")
@@ -24,4 +26,5 @@ rescue => e
   puts("\n")
   SlugCompiler.log_error("measure=slugc.error elapsed=#{Time.now - start}", e)
   raise if ENV["DEBUG"]
+  abort
 end


### PR DESCRIPTION
Currently slug-compile rescues build errors and exits with a zero status afterward, which isn't very friendly for use within git hooks and other scripts.

These changes amend the code to exit with a non-zero status on failure.
