### PR TITLE
fix end-of-line code issues

### DIFF
--- a/lib/slug_compiler.rb
+++ b/lib/slug_compiler.rb
@@ -156,7 +156,7 @@ module SlugCompiler
     path = File.join(build_dir, "Procfile")
     return unless File.exists?(path)
 
-    process_types = File.read(path).split("\n").inject({}) do |ps, line|
+    process_types = File.foreach(path, mode: "rt").inject({}) do |ps, line|
       if m = line.match(/^([a-zA-Z0-9_]+):?\s+(.*)/)
         ps[m[1]] = m[2]
       end


### PR DESCRIPTION
Read "Procfile" using universal newline mode.

Also read line by line with `File.foreach` enumerator, instead of slurping by `File.read`.
